### PR TITLE
fix monit jackett conf file

### DIFF
--- a/updates/monit/jackett
+++ b/updates/monit/jackett
@@ -1,4 +1,4 @@
-check process Jackett matching "mono"
+check process Jackett matching "/opt/jackett/JackettConsole.exe"
     start program = "/usr/sbin/service jackett start"
     stop program = "/usr/sbin/service jackett stop"
     if failed host 127.0.0.1 port 9117 then restart


### PR DESCRIPTION
There are several processes matching mono, but only one gets monitored. If the one being monitored fails, jackett is restarted, which does not fix the process being monitored, and therefore creating a restart loop. Changed script to monitor only jackett. This can be verified by the following from the command line;

monit procmatch mono

monit procmatch /opt/jackett/JackettConsole.exe
